### PR TITLE
Fixed crash on building in console

### DIFF
--- a/xcodesupport/Xcode5/Eero Xcode Plugin/Eero Xcode Plugin/AXACustomLanguageSupportPlugin.m
+++ b/xcodesupport/Xcode5/Eero Xcode Plugin/Eero Xcode Plugin/AXACustomLanguageSupportPlugin.m
@@ -65,6 +65,8 @@
     if (self = [super init]) {
 
       _pluginBundle = bundle;
+        
+      [self addCustomLanguages];
 
       [NSNotificationCenter.defaultCenter addObserver: self
                                               selector: @selector( applicationDidFinishLaunching: )
@@ -140,8 +142,6 @@
                            selector: @selector( projectDidChange: )
                                name: @"PBXProjectDidChangeNotification"
                              object: nil];
-
-    [self addCustomLanguages];
   }
 
   //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Build with xcodebuild will cause crash due to NSInvalidArgumentException.
